### PR TITLE
Instrument requests with tracing correctly

### DIFF
--- a/src/bin/dns2bin.rs
+++ b/src/bin/dns2bin.rs
@@ -68,11 +68,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             } else {
                 b
             }
-        })
-        // TODO: Our error type doesn't implement Error (only Fail) and
-        //  there are conflicting traits when we try (failure seems to have
-        //  a default impl... but we still get type errors here with `?`).
-        .unwrap();
+        })?;
 
     let mut stdout = io::stdout();
     stdout.write_all(&bytes)?;

--- a/src/donut/resolve.rs
+++ b/src/donut/resolve.rs
@@ -44,12 +44,12 @@ impl UdpResolver {
         let mut client = self.client.clone();
         // Clone the request and use a wrapper so that we can use 'Display' and defer it
         // until needed by the tracing library (e.g. only if log level is INFO or lower).
-        let queries = QueryAdapter::new(req.clone());
+        let queries = QueryDisplay::new(req.clone());
         let res = client.send(req).await?;
         let code = res.response_code();
 
         event!(
-            target: "donut_lookup",
+            target: "donut_dns",
             Level::INFO,
             queries = %queries,
             results = res.answer_count(),
@@ -67,17 +67,17 @@ impl fmt::Debug for UdpResolver {
     }
 }
 
-struct QueryAdapter {
+struct QueryDisplay {
     msg: DnsRequest,
 }
 
-impl QueryAdapter {
+impl QueryDisplay {
     fn new(msg: DnsRequest) -> Self {
-        QueryAdapter { msg }
+        QueryDisplay { msg }
     }
 }
 
-impl fmt::Display for QueryAdapter {
+impl fmt::Display for QueryDisplay {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for (i, q) in self.msg.queries().iter().enumerate() {
             if i > 0 {

--- a/src/donut/response.rs
+++ b/src/donut/response.rs
@@ -23,11 +23,6 @@ use trust_dns_client::op::DnsResponse;
 use trust_dns_client::proto::serialize::binary::BinEncodable;
 use trust_dns_client::rr::{RData, Record};
 
-// TODO: These methods Should Just Work with multiple responses?
-
-///
-///
-///
 #[derive(Clone, Default, Debug, PartialEq, Eq, Hash)]
 pub struct ResponseMetadata {
     min_ttl: Option<u32>,
@@ -46,23 +41,14 @@ impl From<&DnsResponse> for ResponseMetadata {
     }
 }
 
-///
-///
-///
 #[derive(Debug, Default, Clone)]
 pub struct ResponseEncoderJson;
 
 impl ResponseEncoderJson {
-    ///
-    ///
-    ///
     pub fn new() -> Self {
         ResponseEncoderJson
     }
 
-    ///
-    ///
-    ///
     pub async fn encode(&self, res: DnsResponse) -> DonutResult<(ResponseMetadata, Vec<u8>)> {
         let questions: Vec<JsonQuestion> = res
             .queries()
@@ -91,7 +77,7 @@ impl ResponseEncoderJson {
             res.recursion_desired(),
             res.recursion_available(),
             false,
-            true,
+            res.checking_disabled(),
             questions,
             answers,
         ))
@@ -101,9 +87,6 @@ impl ResponseEncoderJson {
     }
 }
 
-///
-///
-///
 pub fn record_to_data(record: &Record) -> String {
     match record.rdata() {
         RData::A(v) => v.to_string(),
@@ -254,23 +237,14 @@ impl JsonResponse {
     }
 }
 
-///
-///
-///
 #[derive(Debug, Default, Clone)]
 pub struct ResponseEncoderWire;
 
 impl ResponseEncoderWire {
-    ///
-    ///
-    ///
     pub fn new() -> Self {
         ResponseEncoderWire
     }
 
-    ///
-    ///
-    ///
     pub async fn encode(&self, res: DnsResponse) -> DonutResult<(ResponseMetadata, Vec<u8>)> {
         Ok((ResponseMetadata::from(&res), res.to_bytes()?))
     }


### PR DESCRIPTION
Fix previous uses of tracing to work correctly with futures and make
sure DNS requests are valid before sending them upstream.